### PR TITLE
Corrige banco rm

### DIFF
--- a/banco
+++ b/banco
@@ -20,7 +20,7 @@ case $1 in
       ;;
 
     rm)
-        docker rm $(docker ps -a)
+        docker rm hospebem-db
       ;;
 
   *)


### PR DESCRIPTION
Essa PR corrige o comando `./banco rm`.

Atualmente ele delete todos os containers da máquina, quando deveria deletar somente o container do banco do hospebem.