### PR TITLE
Execução automatica das migrações

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,7 @@ buildscript {
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
-        classpath "org.postgresql:postgresql:42.2.5"
     }
-}
-
-plugins {
-    id "org.flywaydb.flyway" version "5.1.4"
 }
 
 apply plugin: 'java'
@@ -28,7 +23,7 @@ dependencies {
     compile "com.h2database:h2"
     compile "org.postgresql:postgresql:42.2.5"
     compile('org.springframework.boot:spring-boot-starter-security')
-
+    compile "org.flywaydb:flyway-core"
     compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity4:3.0.2.RELEASE'
 
     testCompile 'junit:junit:4.12'
@@ -51,12 +46,6 @@ task stopRunningJar(type: Exec) {
     description = "Para aplicacao que foi iniciada por :app:startFromJar"
 
     commandLine "${rootDir}/scripts/local-test-server", "stop", "$buildDir/libs/app.jar", "$buildDir"
-}
-
-flyway {
-    url = System.getenv("SPRING_DATASOURCE_URL") ?: 'jdbc:postgresql://localhost:5432/hospebem'
-    user = System.getenv("SPRING_DATASOURCE_USERNAME") ?: 'postgres'
-    password = System.getenv("SPRING_DATASOURCE_PASSWORD") ?: 'hospebem'
 }
 
 bootRun {

--- a/build.gradle
+++ b/build.gradle
@@ -23,4 +23,3 @@ task stage {
 }
 
 copyToLib.mustRunAfter(':app:build')
-stage.finalizedBy(':app:flywayMigrate')


### PR DESCRIPTION
Configurei o spring para executar as migrações automaticamente ao executar a aplicação (bootrun), desta forma não precisamos mais executar mais o ` ./gradlew flywaymigrate -i `.