### PR TITLE
Melhoria: Remove cabecalho duplicado na edicao de solicitacao

### DIFF
--- a/app/src/main/resources/templates/solicitacao/editaPaciente.html
+++ b/app/src/main/resources/templates/solicitacao/editaPaciente.html
@@ -6,8 +6,6 @@
 </head>
 <body>
 
-<div th:include="@{./partes/cabecalhoPadrao}"/>
-
 <main>
     <div class="card-content valign center has-text-centered">
         <div  class="columns">


### PR DESCRIPTION
Havia uma duplicação do cabeçalho na página de edição de solicitações. Esta PR remove o cabeçalho duplicado.

![screenshot from 2018-11-21 11-51-51](https://user-images.githubusercontent.com/4705127/48846056-4478c980-ed85-11e8-894b-ed0be0b48a4d.png)
