### PR TITLE
Corrige bug no CSV: datas nulas

### DIFF
--- a/app/src/main/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvService.java
+++ b/app/src/main/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvService.java
@@ -2,8 +2,11 @@ package com.thoughtworks.aceleradora.solicitacao.dominio;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.stream.Stream;
+
+import static com.thoughtworks.aceleradora.solicitacao.dominio.Solicitacao.Status.*;
 import static java.util.stream.Collectors.joining;
 
 @Service
@@ -28,9 +31,9 @@ public class SolicitacaoCsvService {
 
         String listaSolicitacoesRelatorio = solicitacoes
                 .stream()
-                .filter(solicitacao -> solicitacao.getStatus() == (Solicitacao.Status.HOSPEDE) ||
-                        solicitacao.getStatus() == (Solicitacao.Status.EX_HOSPEDE) ||
-                        solicitacao.getStatus() == (Solicitacao.Status.NEGADO)
+                .filter(solicitacao -> solicitacao.getStatus() == HOSPEDE ||
+                        solicitacao.getStatus() == EX_HOSPEDE ||
+                        solicitacao.getStatus() == NEGADO
                 )
                 .map(solicitacao -> juntar(
                         paciente(solicitacao),
@@ -73,22 +76,4 @@ public class SolicitacaoCsvService {
         return Stream.of(valores).collect(joining(","));
     }
 
-    private String getAcompanhantesToString(Solicitacao solicitacao) {
-        StringBuilder retorno = new StringBuilder(" ");
-
-        if(solicitacao !=null) {
-            for (Acompanhante acompanhante : solicitacao.getAcompanhantes()) {
-                if (acompanhante != null) {
-                    retorno
-                            .append(acompanhante.getNome())
-                            .append(",")
-                            .append(acompanhante.getGenero())
-                            .append(",")
-                            .append(acompanhante.getDataNascimento().toString())
-                            .append(",");
-                }
-            }
-        }
-        return retorno.toString();
-    }
 }

--- a/app/src/main/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvService.java
+++ b/app/src/main/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvService.java
@@ -3,7 +3,9 @@ package com.thoughtworks.aceleradora.solicitacao.dominio;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.thoughtworks.aceleradora.solicitacao.dominio.Solicitacao.Status.*;
@@ -48,10 +50,10 @@ public class SolicitacaoCsvService {
     private String paciente(Solicitacao solicitacao) {
         return juntar(
                 solicitacao.getNome(), solicitacao.getStatus().toString(),
-                solicitacao.getGenero(), solicitacao.getDataNascimento().toString(),
+                solicitacao.getGenero(), data(solicitacao.getDataNascimento()),
                 solicitacao.getSituacao(), solicitacao.getOrgao(), solicitacao.getCadeirante(),
-                solicitacao.getTelefone(), solicitacao.getDataEntrada().toString(),
-                solicitacao.getDataSaida().toString()
+                solicitacao.getTelefone(), data(solicitacao.getDataEntrada()),
+                data(solicitacao.getDataSaida())
         );
     }
 
@@ -68,8 +70,12 @@ public class SolicitacaoCsvService {
                 .stream()
                 .map(acompanhante -> juntar(
                         acompanhante.getNome(), acompanhante.getGenero(),
-                        acompanhante.getDataNascimento().toString()))
+                        data(acompanhante.getDataNascimento())))
                 .collect(joining(","));
+    }
+
+    private String data(LocalDate data) {
+        return Optional.ofNullable(data).map(LocalDate::toString).orElse("-");
     }
 
     private String juntar(String... valores) {

--- a/app/src/test/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvServiceTest.java
+++ b/app/src/test/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvServiceTest.java
@@ -1,0 +1,157 @@
+package com.thoughtworks.aceleradora.solicitacao.dominio;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+
+import static com.thoughtworks.aceleradora.solicitacao.dominio.Solicitacao.Status.*;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SolicitacaoCsvServiceTest {
+
+    @Mock
+    private SolicitacaoRepository repository;
+
+    private SolicitacaoCsvService service;
+
+    @Before
+    public void setUp() {
+        service = new SolicitacaoCsvService(repository);
+    }
+
+    @Test
+    public void filtraSolicitacoesAceitasEPendentesETrataDatasNulas() {
+        Solicitacao aceita = new Solicitacao() {{
+            setNome("Aceita");
+            setStatus(ACEITO);
+
+        }};
+
+        Solicitacao negada = new Solicitacao() {{
+            setNome("Negada");
+            setStatus(NEGADO);
+            setGenero("?");
+            setDataNascimento(LocalDate.parse("1998-12-20"));
+            setSituacao("PRE_TRANSPLANTE");
+            setOrgao("Apendice");
+            setCadeirante("Sim");
+            setTelefone("7777");
+            setDataEntrada(LocalDate.parse("2018-12-20"));
+            setDataSaida(LocalDate.parse("2019-01-20"));
+
+            setEndereco(new Endereco() {{
+                setRua("Rua dos Sabias");
+                setCidade("Alvorada");
+                setBairro("Jardim Algarve");
+                setNumero("1000");
+                setUf("RS");
+            }});
+
+            setAcompanhantes(singletonList(
+                    new Acompanhante() {{
+                        setNome("Acompanhante Negado");
+                        setGenero("?");
+                        setDataNascimento(LocalDate.parse("1999-12-20"));
+                    }}
+            ));
+        }};
+
+        Solicitacao hospede = new Solicitacao() {{
+            setNome("Hospede");
+            setStatus(HOSPEDE);
+            setGenero("?");
+            setDataNascimento(LocalDate.parse("1998-12-21"));
+            setSituacao("PRE_TRANSPLANTE");
+            setOrgao("Nariz");
+            setCadeirante("Nao");
+            setTelefone("8888");
+            setDataEntrada(LocalDate.parse("2018-12-21"));
+            setDataSaida(LocalDate.parse("2019-01-20"));
+
+            setEndereco(new Endereco() {{
+                setRua("Rua das Caturritas");
+                setCidade("Alvorada");
+                setBairro("Jardim Algarve");
+                setNumero("1000");
+                setUf("RS");
+            }});
+
+            setAcompanhantes(singletonList(
+                    new Acompanhante() {{
+                        setNome("Acompanhante Hospede");
+                        setGenero("?");
+                        setDataNascimento(LocalDate.parse("1999-12-20"));
+                    }}
+            ));
+        }};
+
+        Solicitacao exHospede = new Solicitacao() {{
+            setNome("ExHospede");
+            setStatus(EX_HOSPEDE);
+            setGenero("?");
+            setDataNascimento(LocalDate.parse("1998-12-22"));
+            setSituacao("PRE_TRANSPLANTE");
+            setOrgao("Pele");
+            setCadeirante("Sim");
+            setTelefone("9999");
+            setDataEntrada(LocalDate.parse("2018-12-22"));
+            setDataSaida(LocalDate.parse("2019-01-20"));
+
+            setEndereco(new Endereco() {{
+                setRua("Rua dos biguas");
+                setCidade("Alvorada");
+                setBairro("Jardim Algarve");
+                setNumero("1000");
+                setUf("RS");
+            }});
+
+            setAcompanhantes(singletonList(
+                    new Acompanhante() {{
+                        setNome("Acompanhante Ex Hospede");
+                        setGenero("?");
+                        setDataNascimento(LocalDate.parse("1999-12-20"));
+                    }}
+            ));
+        }};
+
+        Solicitacao pendente = new Solicitacao() {{
+            setNome("Pendente");
+            setStatus(PENDENTE);
+        }};
+
+        when(repository.findAll()).thenReturn(asList(aceita, negada, hospede, exHospede, pendente));
+
+        String resultado = service.solicitacoesRelatorio();
+
+        assertThat(resultado, equalTo(
+                "Nome,Status,Gênero,Data de Nascimento,Situacao,Órgão,Rua,Número," +
+                        "Cidade,Bairro,UF,Cadeirante,Telefone,Data de Entrada,Data de Saída," +
+                        "Nome Acompanhante,Gênero Acompanhante,Data Nascimento Acompanhante," +
+                        "Nome Acompanhante2,Gênero Acompanhante2,Data Nascimento Acompanhante2" +
+                        "\n" +
+                        "Negada,NEGADO,?,1998-12-20,PRE_TRANSPLANTE,Apendice,Sim,7777," +
+                        "2018-12-20,2019-01-20,Rua dos Sabias,1000,Alvorada,Jardim Algarve,RS," +
+                        "Acompanhante Negado,?,1999-12-20" +
+                        "\n" +
+                        "Hospede,HOSPEDE,?,1998-12-21,PRE_TRANSPLANTE,Nariz,Nao,8888,2018-12-21," +
+                        "2019-01-20,Rua das Caturritas,1000,Alvorada,Jardim Algarve,RS," +
+                        "Acompanhante Hospede,?,1999-12-20" +
+                        "\n" +
+                        "ExHospede,EX_HOSPEDE,?,1998-12-22,PRE_TRANSPLANTE,Pele,Sim,9999,2018-12-22," +
+                        "2019-01-20,Rua dos biguas,1000,Alvorada,Jardim Algarve,RS," +
+                        "Acompanhante Ex Hospede,?,1999-12-20"
+        ));
+    }
+}

--- a/app/src/test/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvServiceTest.java
+++ b/app/src/test/java/com/thoughtworks/aceleradora/solicitacao/dominio/SolicitacaoCsvServiceTest.java
@@ -7,9 +7,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Collections;
 
 import static com.thoughtworks.aceleradora.solicitacao.dominio.Solicitacao.Status.*;
 import static java.util.Arrays.asList;
@@ -101,13 +98,13 @@ public class SolicitacaoCsvServiceTest {
             setNome("ExHospede");
             setStatus(EX_HOSPEDE);
             setGenero("?");
-            setDataNascimento(LocalDate.parse("1998-12-22"));
+            setDataNascimento(null);
             setSituacao("PRE_TRANSPLANTE");
             setOrgao("Pele");
             setCadeirante("Sim");
             setTelefone("9999");
-            setDataEntrada(LocalDate.parse("2018-12-22"));
-            setDataSaida(LocalDate.parse("2019-01-20"));
+            setDataEntrada(null);
+            setDataSaida(null);
 
             setEndereco(new Endereco() {{
                 setRua("Rua dos biguas");
@@ -121,7 +118,7 @@ public class SolicitacaoCsvServiceTest {
                     new Acompanhante() {{
                         setNome("Acompanhante Ex Hospede");
                         setGenero("?");
-                        setDataNascimento(LocalDate.parse("1999-12-20"));
+                        setDataNascimento(null);
                     }}
             ));
         }};
@@ -149,9 +146,9 @@ public class SolicitacaoCsvServiceTest {
                         "2019-01-20,Rua das Caturritas,1000,Alvorada,Jardim Algarve,RS," +
                         "Acompanhante Hospede,?,1999-12-20" +
                         "\n" +
-                        "ExHospede,EX_HOSPEDE,?,1998-12-22,PRE_TRANSPLANTE,Pele,Sim,9999,2018-12-22," +
-                        "2019-01-20,Rua dos biguas,1000,Alvorada,Jardim Algarve,RS," +
-                        "Acompanhante Ex Hospede,?,1999-12-20"
+                        "ExHospede,EX_HOSPEDE,?,-,PRE_TRANSPLANTE,Pele,Sim,9999,-," +
+                        "-,Rua dos biguas,1000,Alvorada,Jardim Algarve,RS," +
+                        "Acompanhante Ex Hospede,?,-"
         ));
     }
 }


### PR DESCRIPTION
Essa PR corrige o bug de `NullPointerException` que acontecia quando o CsvService tentava processar Solicitações e acompanhantes com datas nulas. Idealmente, deveríamos melhorar esse serviço, pois ele está meio difícil de entender. Podemos:
- Filtrar solicitações por status no repositório
- Particionar construção do CSV de solicitações, acompanhantes e endereços.
- Formatar datas do CSV usando padrão brasileiro de datas